### PR TITLE
React Image Fix

### DIFF
--- a/react-js/react-basic/src/App.jsx
+++ b/react-js/react-basic/src/App.jsx
@@ -7,12 +7,15 @@ import ReactDOM from "react-dom/client";
 // importing App.css
 import "./App.css";
 
+// importing image from path
+import reactSvg from "./assets/react.svg"
+
 // creating a component named 'Header'
 function Header() {
 	return (
 		<>
 			<header>
-				<img src="./assets/react.svg" alt="React Image" />
+				<img src={reactSvg} alt="React Image" />
 				<h2>Welcome to React Course !</h2>
 				<p>We are going to learn React Basics in this course.</p>
 			</header>


### PR DESCRIPTION
This change resolves #8 by importing the image using 'import' statement.
In React, you typically import images in JSX files using the import statement. The syntax you used 'img src="./assets/react.svg" alt="React Image"' is used in regular HTML, but in React, you need to leverage the import statement to bring in the image file.